### PR TITLE
Moved kefir to peerDependencies:

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "codecov": "^1.0.1",
     "eslint": "^3.16.0",
     "eslint-plugin-react": "^6.10.0",
+    "kefir": "^3.7.0",
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
     "react-dom": "^15.4.2"
@@ -44,10 +45,12 @@
   "dependencies": {
     "infestines": "^0.4.0",
     "karet": "^1.0.0",
-    "kefir": "^3.7.0",
     "kefir.atom": "^5.0.1",
     "kefir.combines": "^4.0.0",
     "partial.lenses": ">=8.0.0 <10.0.0",
     "ramda": "^0.23.0"
+  },
+  "peerDependencies": {
+    "kefir": "^3.7.0"
   }
 }


### PR DESCRIPTION
- In order to ensure only one version of kefir is used within a project due to instanceof operations

We were running into issues where `instanceof Observable` operations were failing because of mismatching or multiple same versions (due to not doing empty npm install) of Kefir.

I moved `Kefir` to peerDependencies to ensure that karet.util uses same Kefir module.