### PR TITLE
Migrated to new Context API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.18.1
+
+Migrated the context implementation to use the React Context API and also marked
+it obsolete.  Just use the React Context API.
+
 ## 0.18.0
 
 Major reorganization of the library on the road towards v1.0.0.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ A collection of utilities for working with
     * [`U.thru(any, ...fns)`](#U-thru)
     * [`U.toPartial(fn)`](#U-toPartial)
   * [React helpers](#react-helpers)
-    * [Context](#context)
-      * [`<U.Context context={context} />`](#U-Context)
-      * [`U.withContext((props, context) => element)`](#U-withContext)
+    * ~~[Context](#context)~~
+      * ~~[`<U.Context context={context} />`](#U-Context)~~
+      * ~~[`U.withContext((props, context) => element)`](#U-withContext)~~
     * [Binding](#binding)
       * [`U.getProps({...propName: atom})`](#U-getProps)
       * [`U.setProps({...propName: observable})`](#U-setProps)
@@ -538,9 +538,12 @@ U.toPartial((x, y) => x + y)(1, 2)
 
 ### <a id="react-helpers"></a> [≡](#contents) [React helpers](#react-helpers)
 
-#### <a id="context"></a> [≡](#contents) [Context](#context)
+#### <a id="context"></a> [≡](#contents) ~~[Context](#context)~~
 
-##### <a id="U-Context"></a> [≡](#contents) [`<U.Context context={context} />`](#U-Context)
+##### <a id="U-Context"></a> [≡](#contents) ~~[`<U.Context context={context} />`](#U-Context)~~
+
+**WARNING: `U.Context` has been obsoleted. Just use the new [React context
+API](https://reactjs.org/docs/context.html).**
 
 `U.Context` is a component that allows one to set the context for child
 components.  See also [`U.withContext`](#U-withContext).
@@ -556,7 +559,10 @@ For example:
 <U.Context/>
 ```
 
-##### <a id="U-withContext"></a> [≡](#contents) [`U.withContext((props, context) => element)`](#U-withContext)
+##### <a id="U-withContext"></a> [≡](#contents) ~~[`U.withContext((props, context) => element)`](#U-withContext)~~
+
+**WARNING: `U.withContext` has been obsoleted. Just use the new [React context
+API](https://reactjs.org/docs/context.html).**
 
 `U.withContext` creates a component that takes both the props and the context as
 parameters.  See also [`U.Context`](#U-Context).

--- a/package-lock.json
+++ b/package-lock.json
@@ -335,7 +335,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.3",
@@ -1053,12 +1054,6 @@
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-          "dev": true
-        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -1148,14 +1143,6 @@
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -1166,14 +1153,6 @@
       "requires": {
         "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-          "dev": true
-        }
       }
     },
     "babel-template": {
@@ -1344,7 +1323,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.3",
+        "fsevents": "1.2.0",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1352,6 +1331,13 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true,
+      "optional": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -1536,9 +1522,10 @@
       "dev": true
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1673,6 +1660,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "0.4.21"
       }
@@ -1978,6 +1966,7 @@
       "version": "0.8.16",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "dev": true,
       "requires": {
         "core-js": "1.2.7",
         "isomorphic-fetch": "2.2.1",
@@ -1986,6 +1975,14 @@
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
         "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
       }
     },
     "figures": {
@@ -2076,6 +2073,16 @@
         "mime-types": "2.1.18"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minipass": "2.2.4"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -2089,14 +2096,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.0.tgz",
+      "integrity": "sha512-ROrBIbmw4ulxmQTwYAAGyN/0xgIOAFd6gX/K3F1aGLP/K5KxkubrlGISMV5EEWEB7qtiEdE0HpaqvMMHR+Ib6w==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.6.39"
+        "node-pre-gyp": "0.9.1"
       },
       "dependencies": {
         "abbrev": {
@@ -2108,8 +2115,6 @@
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
@@ -2138,43 +2143,31 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -2183,7 +2176,6 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "dev": true,
           "requires": {
             "inherits": "2.0.3"
           }
@@ -2191,7 +2183,6 @@
         "boom": {
           "version": "2.10.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -2199,7 +2190,6 @@
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
@@ -2207,20 +2197,15 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -2230,15 +2215,13 @@
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -2247,13 +2230,11 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -2261,25 +2242,19 @@
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "debug": {
           "version": "2.6.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2292,8 +2267,7 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -2310,7 +2284,6 @@
         "ecc-jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -2318,26 +2291,19 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -2346,13 +2312,11 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -2363,8 +2327,6 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -2390,24 +2352,19 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -2419,20 +2376,15 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -2447,7 +2399,6 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -2457,14 +2408,11 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "http-signature": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.0",
@@ -2474,7 +2422,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -2482,8 +2429,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.4",
@@ -2501,25 +2447,19 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "jodid25519": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -2528,41 +2468,30 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "jsprim": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.0.2",
@@ -2572,21 +2501,17 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
-          "dev": true,
           "requires": {
             "mime-db": "1.27.0"
           }
@@ -2594,47 +2519,67 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
+          "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
+            "needle": "2.2.0",
             "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
             "npmlog": "4.1.0",
             "rc": "1.2.1",
-            "request": "2.81.0",
             "rimraf": "2.6.1",
             "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "tar": "4.4.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+              "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+              }
+            }
           }
         },
         "nopt": {
@@ -2666,9 +2611,7 @@
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2679,7 +2622,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -2708,31 +2650,23 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.1",
@@ -2757,7 +2691,6 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
@@ -2771,8 +2704,6 @@
         "request": {
           "version": "2.81.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -2801,15 +2732,13 @@
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2832,7 +2761,6 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -2840,8 +2768,6 @@
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "asn1": "0.2.3",
             "assert-plus": "1.0.0",
@@ -2856,9 +2782,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -2875,16 +2799,13 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -2903,7 +2824,6 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -2913,8 +2833,6 @@
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.8",
             "fstream": "1.0.11",
@@ -2929,8 +2847,6 @@
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -2938,8 +2854,6 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -2947,31 +2861,23 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "verror": {
           "version": "1.3.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "extsprintf": "1.0.2"
           }
@@ -2987,8 +2893,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         }
       }
     },
@@ -3201,6 +3106,7 @@
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
       "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
       }
@@ -3210,6 +3116,16 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -3469,7 +3385,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -3508,6 +3425,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "1.7.3",
         "whatwg-fetch": "2.0.4"
@@ -3522,7 +3440,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.11.0",
@@ -3622,9 +3541,9 @@
       }
     },
     "karet": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/karet/-/karet-3.2.0.tgz",
-      "integrity": "sha512-vOL6jrFQcgV5GOf4GkXUMLBLJvCHFBjZK0a36Box33Pjmkv+OOiP3Xt7U57qAanyp+gNKLaoF24UuDyLOkcOeg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/karet/-/karet-3.2.2.tgz",
+      "integrity": "sha512-xdSzrmQvPrG+SJ0DAfM/fhCwD9xvgoQ2+xVfCTwP4F7FN45Y0aqE7OtJAjjV8iT/3rrcs3d3DJflVCSDJYIO8g==",
       "requires": {
         "infestines": "0.4.7"
       }
@@ -3644,7 +3563,7 @@
       "integrity": "sha512-MH0JrkA4HEJhp8EK3E1neweCg/xyJxZB6jMhtd/0nr8NFpkIfTY7s2rJb8t9+LzQYofMN/5wgtKshuW7/+j8yQ==",
       "requires": {
         "infestines": "0.4.7",
-        "partial.lenses": "13.9.0"
+        "partial.lenses": "13.10.0"
       }
     },
     "kefir.combines": {
@@ -3656,13 +3575,13 @@
       }
     },
     "kefir.partial.lenses": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/kefir.partial.lenses/-/kefir.partial.lenses-13.9.0.tgz",
-      "integrity": "sha512-AcapquW6ffvKIbEyYQDJV7XFrPaHh8L/VKFa93Mw6DFTCxLRd27sSCK/U8ppzo/LlHv1B7wTjYM8uKNo+uyV4w==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/kefir.partial.lenses/-/kefir.partial.lenses-13.10.0.tgz",
+      "integrity": "sha512-QUmkA/XFpSRXNXGRW8/FTKAWlpRHVw8Q2LLRDQP5cbAN/yJlISttCmmUYXvJuZn4KD2NsUkJyZ7BXA/QVkNZRA==",
       "dev": true,
       "requires": {
         "kefir.combines": "4.3.0",
-        "partial.lenses": "13.9.0"
+        "partial.lenses": "13.10.0"
       }
     },
     "kefir.ramda": {
@@ -3704,6 +3623,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -3716,6 +3636,14 @@
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "magic-string": {
@@ -3783,6 +3711,26 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minipass": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minipass": "2.2.4"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -3869,10 +3817,23 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+      "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.21",
+        "sax": "1.2.4"
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -3885,6 +3846,24 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+      "dev": true,
+      "optional": true
+    },
+    "npm-packlist": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+      "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.3"
       }
     },
     "number-is-nan": {
@@ -6582,7 +6561,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.0.11",
@@ -6668,9 +6648,9 @@
       }
     },
     "partial.lenses": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-13.9.0.tgz",
-      "integrity": "sha512-divN6q6nG4nXtkOZ3+32LQJNm3/kNJnCGeWWJRnx1C0PhPDgCVb7r8s+K48RZNgDrB/R4jt64dXGM84ckV3Rbw==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-13.10.0.tgz",
+      "integrity": "sha512-0SBwZ5e2lkmQh8KIptgEf9s93xRrNb5FCqkXENV/TT08YlXI/PYC5mvVJifpTFbH12hbMA46GK66Vk+ztWK0XA==",
       "requires": {
         "infestines": "0.4.7"
       }
@@ -6760,6 +6740,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "2.0.6"
       }
@@ -6768,6 +6749,7 @@
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
       "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -7219,7 +7201,15 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true,
+      "optional": true
     },
     "semver": {
       "version": "5.5.0",
@@ -7237,7 +7227,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -7543,7 +7534,8 @@
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "dev": true
     },
     "uglify-es": {
       "version": "3.3.9",
@@ -7652,7 +7644,8 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
     },
     "which": {
       "version": "1.3.0",
@@ -7685,9 +7678,9 @@
       }
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.7.0",
     "kefir": "^3.8.3",
-    "kefir.partial.lenses": "^13.9.0",
+    "kefir.partial.lenses": "^13.10.0",
     "kefir.ramda": "^0.25.0",
     "mocha": "^5.1.1",
     "nyc": "^11.7.1",
@@ -64,8 +64,7 @@
     "karet": "^3.1.0",
     "kefir.atom": "^5.3.0",
     "kefir.combines": "^4.3.0",
-    "partial.lenses": "^13.0.0",
-    "prop-types": "^15.5.6"
+    "partial.lenses": "^13.0.0"
   },
   "peerDependencies": {
     "kefir": "^3.7.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,6 @@ const globals = {
   'kefir.atom': 'kefir.atom',
   'kefir.combines': 'kefir.combines',
   'partial.lenses': 'L',
-  'prop-types': 'PropTypes',
   ramda: 'R',
   react: 'React'
 }
@@ -34,6 +33,7 @@ const build = ({NODE_ENV, format, suffix}) => ({
         'node_modules/react/index.js': [
           'Component',
           'Fragment',
+          'createContext',
           'createElement',
           'forwardRef'
         ]

--- a/src/karet.util.js
+++ b/src/karet.util.js
@@ -4,8 +4,16 @@ import * as I from 'infestines'
 
 import * as L from 'partial.lenses'
 import * as C from 'kefir.combines'
-import {Component} from 'react'
-import PropTypes from 'prop-types'
+import * as React from 'react'
+
+const header = 'karet.util: '
+
+function warn(f, m) {
+  if (!f.warned) {
+    f.warned = 1
+    console.warn(header + m)
+  }
+}
 
 // Kefir ///////////////////////////////////////////////////////////////////////
 
@@ -172,31 +180,29 @@ export const onUnmount = effect =>
 
 // Context ---------------------------------------------------------------------
 
-const types = {context: PropTypes.any}
+const {Provider, Consumer} = React.createContext(I.object0)
 
-export const Context = I.inherit(
-  function Context(props) {
-    Component.call(this, props)
-  },
-  Component,
-  {
-    getChildContext() {
-      return {context: this.props.context}
-    },
-    render() {
-      return this.props.children
-    }
-  },
-  {
-    childContextTypes: types
-  }
-)
+export const Context = (process.env.NODE_ENV === 'production'
+  ? I.id
+  : fn => props => {
+      warn(
+        Context,
+        '`Context` has been obsoleted.  Just use the new React context API.'
+      )
+      return fn(props)
+    })(({context, ...props}) => <Provider value={context} {...props} />)
 
-export function withContext(originalFn) {
-  const fn = (props, {context}) => originalFn(props, context)
-  fn.contextTypes = types
-  return fn
-}
+export const withContext = (process.env.NODE_ENV === 'production'
+  ? I.id
+  : fn => props => {
+      warn(
+        withContext,
+        '`withContext` has been obsoleted.  Just use the new React context API.'
+      )
+      return fn(props)
+    })(toElem => props => (
+  <Consumer>{context => toElem(props, context)}</Consumer>
+))
 
 // DOM Binding -----------------------------------------------------------------
 


### PR DESCRIPTION
The new React context API is more modular, because each created context is independent from other contexts.  The Karet Util context API is perhaps slightly more concise to use, but does not help to avoid context property name collisions, so we will mark the Karet Util context API as obsolete.